### PR TITLE
chore: change Ruff version in GitHub actions  to 0.4.10

### DIFF
--- a/.github/workflows/pep.yml
+++ b/.github/workflows/pep.yml
@@ -20,7 +20,10 @@ jobs:
     - uses: actions/checkout@v4
     - name: Linting
       uses: chartboost/ruff-action@v1
+      with:
+        version: 0.4.10
     - name: Formatting Check
       uses: chartboost/ruff-action@v1
       with:
         args: 'format --check'
+        version: 0.4.10


### PR DESCRIPTION
ruffs GitHub Actions version didn't match poetry.lock ruffs version. Fixed (by Jacoor in other commit).

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update the Ruff version in the GitHub Actions workflow to 0.4.10 to ensure consistency with the version specified in poetry.lock.

CI:
- Update Ruff version to 0.4.10 in GitHub Actions workflow for consistency with poetry.lock.

<!-- Generated by sourcery-ai[bot]: end summary -->