### PR TITLE
BUG [8695gb9wq]: missing error message when adding non existing user as moderator

### DIFF
--- a/core/tests/test_views.py
+++ b/core/tests/test_views.py
@@ -335,3 +335,19 @@ def test_remove_moderator(client: Client, user: User, community: Community) -> N
     assert response.status_code == 302
 
     assert not CommunityMember.objects.filter(community=community, user=user, role=CommunityMember.MODERATOR).exists()
+
+
+def test_add_non_existing_moderator(client: Client, community: Community, user: User) -> None:
+    admin_password = generate_random_password()
+
+    admin = User.objects.create_user(email="admin@example.com", password=admin_password, nickname="adminnick")
+
+    client.force_login(admin)
+    CommunityMember.objects.create(community=community, user=admin, role=CommunityMember.ADMIN)
+
+    url = reverse("community-detail", kwargs={"slug": community.slug})
+    form_data = {"nickname": "nonexistentuser"}
+
+    response = client.post(url, {"action": "add_moderator", **form_data})
+    assert response.status_code == 200
+    assert "Invalid user or nickname." in response.context["messages"]._loaded_messages[0].message

--- a/core/tests/test_views.py
+++ b/core/tests/test_views.py
@@ -350,4 +350,6 @@ def test_add_non_existing_moderator(client: Client, community: Community, user: 
 
     response = client.post(url, {"action": "add_moderator", **form_data})
     assert response.status_code == 200
-    assert "Invalid user or nickname." in response.context["messages"]._loaded_messages[0].message
+
+    messages = list(response.context["messages"])
+    assert any("Invalid user or nickname." in message.message for message in messages)

--- a/core/views.py
+++ b/core/views.py
@@ -176,25 +176,27 @@ class CommunityDetailView(DetailView):
         ).select_related("user")
         return context
 
-    def post_add_moderator(self: "CommunityDetailView", request: "HttpRequest", *args: any, **kwargs: any) -> any:  # noqa: ARG002
+    def post_add_moderator(self: "CommunityDetailView", request: "HttpRequest", *args: any, **kwargs: any) -> any:
         add_moderator_form = AddModeratorForm(request.POST)
         if add_moderator_form.is_valid():
             user = add_moderator_form.cleaned_data["nickname"]
             self.object.add_moderator(user)
-            return redirect("community-detail", slug=self.object.slug)
         else:
             messages.error(request, "Invalid user or nickname.")
             return self.get(request, *args, **kwargs)
 
-    def post_remove_moderator(self: "CommunityDetailView", request: "HttpRequest", *args: any, **kwargs: any) -> any:  # noqa: ARG002
+        return redirect("community-detail", slug=self.object.slug)
+
+    def post_remove_moderator(self: "CommunityDetailView", request: "HttpRequest", *args: any, **kwargs: any) -> any:
         remove_moderator_form = RemoveModeratorForm(request.POST)
         if remove_moderator_form.is_valid():
             user = remove_moderator_form.cleaned_data["nickname"]
             self.object.remove_moderator(user)
-            return redirect("community-detail", slug=self.object.slug)
         else:
             messages.error(request, "Invalid user or nickname.")
             return self.get(request, *args, **kwargs)
+
+        return redirect("community-detail", slug=self.object.slug)
 
     def post(self: "CommunityDetailView", request: "HttpRequest", *args: any, **kwargs: any) -> any:
         self.object = self.get_object()

--- a/core/views.py
+++ b/core/views.py
@@ -181,14 +181,20 @@ class CommunityDetailView(DetailView):
         if add_moderator_form.is_valid():
             user = add_moderator_form.cleaned_data["nickname"]
             self.object.add_moderator(user)
-        return redirect("community-detail", slug=self.object.slug)
+            return redirect("community-detail", slug=self.object.slug)
+        else:
+            messages.error(request, "Invalid user or nickname.")
+            return self.get(request, *args, **kwargs)
 
     def post_remove_moderator(self: "CommunityDetailView", request: "HttpRequest", *args: any, **kwargs: any) -> any:  # noqa: ARG002
         remove_moderator_form = RemoveModeratorForm(request.POST)
         if remove_moderator_form.is_valid():
             user = remove_moderator_form.cleaned_data["nickname"]
             self.object.remove_moderator(user)
-        return redirect("community-detail", slug=self.object.slug)
+            return redirect("community-detail", slug=self.object.slug)
+        else:
+            messages.error(request, "Invalid user or nickname.")
+            return self.get(request, *args, **kwargs)
 
     def post(self: "CommunityDetailView", request: "HttpRequest", *args: any, **kwargs: any) -> any:
         self.object = self.get_object()


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix missing error message when adding or removing a non-existing user as a moderator by displaying an error message when the form is invalid.

Bug Fixes:
- Add error message when attempting to add or remove a non-existing user as a moderator.

<!-- Generated by sourcery-ai[bot]: end summary -->