### PR TITLE
Fix: trailing slashes and order for api_vews

### DIFF
--- a/core/api_urls.py
+++ b/core/api_urls.py
@@ -3,8 +3,8 @@ from rest_framework.urls import path
 from .api_views import CommunitiesAPIList, CommunityDetailAPIView, CommunityPostsListAPIView, PostAPIListView
 
 urlpatterns = [
-    path("communities", CommunitiesAPIList.as_view(), name="api-communities-list"),
-    path("communities/<slug:slug>", CommunityDetailAPIView.as_view(), name="api-community-detail"),
-    path("communities/<slug:slug>/posts", CommunityPostsListAPIView.as_view(), name="api-communities-posts-list"),
-    path("posts", PostAPIListView.as_view(), name="api-posts-list-view"),
+    path("communities/", CommunitiesAPIList.as_view(), name="api-communities-list"),
+    path("communities/<slug:slug>/", CommunityDetailAPIView.as_view(), name="api-community-detail"),
+    path("communities/<slug:slug>/posts/", CommunityPostsListAPIView.as_view(), name="api-communities-posts-list"),
+    path("posts/", PostAPIListView.as_view(), name="api-posts-list-view"),
 ]

--- a/core/api_views.py
+++ b/core/api_views.py
@@ -8,7 +8,7 @@ from core.serializers import CommunitySerializer, MinimalCommunitySerializer, Po
 
 
 class CommunitiesAPIList(ListAPIView):
-    queryset = Community.objects.exclude(privacy=Community.PRIVATE)
+    queryset = Community.objects.exclude(privacy=Community.PRIVATE).order_by("name")
     serializer_class = MinimalCommunitySerializer
 
 
@@ -24,7 +24,7 @@ class CommunityDetailAPIView(RetrieveAPIView):
 
 
 class PostAPIListView(ListAPIView):
-    queryset = Post.objects.exclude(community__privacy=Community.PRIVATE)
+    queryset = Post.objects.exclude(community__privacy=Community.PRIVATE).order_by("up_votes")
     serializer_class = PostSerializer
 
 
@@ -38,4 +38,4 @@ class CommunityPostsListAPIView(ListAPIView):
         if community.privacy == Community.PRIVATE:
             msg = "Private community is not accessible."
             raise PermissionDenied(msg)
-        return Post.objects.filter(community=community)
+        return Post.objects.filter(community=community).order_by("up_votes")

--- a/core/api_views.py
+++ b/core/api_views.py
@@ -24,7 +24,7 @@ class CommunityDetailAPIView(RetrieveAPIView):
 
 
 class PostAPIListView(ListAPIView):
-    queryset = Post.objects.exclude(community__privacy=Community.PRIVATE).order_by("up_votes")
+    queryset = Post.objects.exclude(community__privacy=Community.PRIVATE).order_by("-updated_at")
     serializer_class = PostSerializer
 
 
@@ -38,4 +38,4 @@ class CommunityPostsListAPIView(ListAPIView):
         if community.privacy == Community.PRIVATE:
             msg = "Private community is not accessible."
             raise PermissionDenied(msg)
-        return Post.objects.filter(community=community).order_by("up_votes")
+        return Post.objects.filter(community=community).order_by("-updated_at")

--- a/core/api_views.py
+++ b/core/api_views.py
@@ -24,7 +24,7 @@ class CommunityDetailAPIView(RetrieveAPIView):
 
 
 class PostAPIListView(ListAPIView):
-    queryset = Post.objects.exclude(community__privacy=Community.PRIVATE).order_by("-updated_at")
+    queryset = Post.objects.exclude(community__privacy=Community.PRIVATE).order_by("-id")
     serializer_class = PostSerializer
 
 
@@ -38,4 +38,4 @@ class CommunityPostsListAPIView(ListAPIView):
         if community.privacy == Community.PRIVATE:
             msg = "Private community is not accessible."
             raise PermissionDenied(msg)
-        return Post.objects.filter(community=community).order_by("-updated_at")
+        return Post.objects.filter(community=community).order_by("-id")


### PR DESCRIPTION
- I added trailing `/` to `api_urls`.
- Changed order of list `api_views` to `-updated_at` - to deal with pytest unexpected order warnings.
- Tried to change it to `-score`, but score is not a field - it's a property.  It cannot be done easily.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix URL handling by adding trailing slashes to API endpoints and adjust queryset ordering to '-updated_at' to resolve pytest order warnings.

Bug Fixes:
- Add trailing slashes to API endpoint URLs to ensure consistent URL handling.

Enhancements:
- Change the ordering of the PostAPIListView and CommunityPostsListAPIView querysets to order by '-updated_at' to address pytest warnings about unexpected order.

<!-- Generated by sourcery-ai[bot]: end summary -->