### PR TITLE
fix code warning

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Cancel Previous Runs
-        if: "!endsWith(github.ref, '/master') && !endsWith(github.ref, '/dev')"
+        if: '!endsWith(github.ref, "/master") && !endsWith(github.ref, "/dev")'
         uses: styfle/cancel-workflow-action@0.11.0
         with:
           access_token: ${{ github.token }}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -9,11 +9,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Cancel Previous Runs
-        if: "!endsWith(github.ref, '/master') && !endsWith(github.ref, '/dev')"
+        if: >-
+          !contains(github.ref, '/master') && !contains(github.ref, '/dev')
         uses: styfle/cancel-workflow-action@0.11.0
         with:
-          access_token: ${{ github.token }}
-
+          access_token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v3.2.0
 
       - name: Set up Python

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Cancel Previous Runs
-        if: '!endsWith(github.ref, "/master") && !endsWith(github.ref, "/dev")'
+        if: "!endsWith(github.ref, '/master') && !endsWith(github.ref, '/dev')"
         uses: styfle/cancel-workflow-action@0.11.0
         with:
           access_token: ${{ github.token }}


### PR DESCRIPTION
Apostrophes change so editor does not mark file red.

## Summary by Sourcery

CI:
- Fix code warning by changing apostrophes in the GitHub Actions workflow file to prevent editor warnings.