### PR TITLE
Changed the title of a form from Polish to English.

### DIFF
--- a/core/templates/core/post-create.html
+++ b/core/templates/core/post-create.html
@@ -3,7 +3,7 @@
 
 {% block content %}
 <div class="container mt-5">
-    <h1 class="mb-4">Dodaj nowy post</h1>
+    <h1 class="mb-4">Add new post</h1>
 
     {% if form.errors %}
     <div class="alert alert-danger" role="alert">


### PR DESCRIPTION
If the whole website is in English, then there is no place to have a title that is in Polish.

## Summary by Sourcery

Bug Fixes:
- Change the title of the post creation form from Polish to English to maintain language consistency.