### PR TITLE
remove pytest warning

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -4,4 +4,3 @@ python_files = tests.py test_*.py *_tests.py
 filterwarnings =
     ignore::django.core.paginator.UnorderedObjectListWarning
 pythonpath = .
-import_mode=importlibs


### PR DESCRIPTION
Sourcery is sometimes stupid. 

Removed `import_mode` from `pytest.ini` as it created a warning in tests. 

---

## Summary by Sourcery

Chores:
- Remove `pythonpath` and `import_mode` from `pytest.ini`.