### PR TITLE
Fix correct redirect, and add message for dismissing report

### DIFF
--- a/core/services.py
+++ b/core/services.py
@@ -19,7 +19,7 @@ def handle_admin_action(action: str, report: PostReport, user: User, request: Ht
     elif action == WARN:
         warn_user(request, report, user)
     elif action == DISMISS_REPORT:
-        dismiss_report(report)
+        dismiss_report(request, report)
 
 
 def ban_user(request: HttpRequest, report: PostReport, user: User) -> None:
@@ -84,6 +84,7 @@ def warn_user(request: HttpRequest, report: PostReport, user: User) -> None:
         messages.success(request, "User has been warned successfully.")
 
 
-def dismiss_report(report: PostReport) -> None:
+def dismiss_report(request: HttpRequest, report: PostReport) -> None:
     report.verified = True
     report.save()
+    messages.success(request, "Post report has been dismissed successfully.")

--- a/core/tests/test_views.py
+++ b/core/tests/test_views.py
@@ -713,7 +713,7 @@ def test_moderator_dashboard_post_valid_action(client: Client, admin: User, post
     data = {"selected_reports": [post_report.id], "action_for_selected": BAN}
     response = client.post(url, data)
     assert response.status_code == 302
-    assert response.url == reverse("home")
+    assert response.url == reverse("moderator-dashboard")
     actions = AdminAction.objects.filter(post_report__in=[post_report])
     assert actions.count() == 1
 
@@ -724,7 +724,7 @@ def test_moderator_dashboard_post_no_selected(client: Client, admin: User) -> No
     data = {"selected_reports": [], "action_for_selected": "approve"}
     response = client.post(url, data)
     assert response.status_code == 302
-    assert response.url == reverse("home")
+    assert response.url == reverse("moderator-dashboard")
 
     actions = AdminAction.objects.all()
     assert actions.count() == 0

--- a/core/views.py
+++ b/core/views.py
@@ -512,7 +512,7 @@ class ModeratorDashboardView(UserPassesTestMixin, LoginRequiredMixin, TemplateVi
         form = GroupAdminActionForm(request.POST)
         if not form.is_valid():
             messages.error(request, "Invalid form submission.")
-            return redirect("home")
+            return redirect("moderator-dashboard")
 
         selected_ids = request.POST.getlist("selected_reports", [])
         reports = PostReport.objects.filter(id__in=selected_ids)
@@ -523,7 +523,7 @@ class ModeratorDashboardView(UserPassesTestMixin, LoginRequiredMixin, TemplateVi
             admin_action = AdminAction(post_report=report, action=action, performed_by=request.user)
             admin_action.save()
             handle_admin_action(action, report, user, request)
-        return redirect("home")
+        return redirect("moderator-dashboard")
 
 
 class PostReportedView(UserPassesTestMixin, LoginRequiredMixin, DetailView):


### PR DESCRIPTION
Bug fix according to -> https://app.clickup.com/t/86991z5kt

## Summary by Sourcery

Fix redirects to the moderator dashboard, correct the dismiss_report signature to include the request, and add a success message when dismissing a report.

Bug Fixes:
- Ensure form errors and post actions in ModeratorDashboardView redirect to "moderator-dashboard" instead of "home"
- Pass the HttpRequest into dismiss_report in handle_admin_action

Enhancements:
- Display a success message when a post report is dismissed

Tests:
- Update tests to assert redirects go to "moderator-dashboard"